### PR TITLE
Alter method of generating Opsman/Director Configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 *.pem
 .idea
 .vagrant

--- a/install-opsman/params.yml
+++ b/install-opsman/params.yml
@@ -6,18 +6,17 @@ s3:
   access_key_id: ((s3_access_key_id))
   region_name: ((s3_region_name))
   buckets:
-    product: ((s3_product_bucket))
-    config: ((s3_config_bucket))
+    product: ((product_bucket))
+    config: ((config_bucket))
   secret_access_key: ((s3_secret_access_key))
   endpoint: ((s3_endpoint))
-opsman_image_wildcard: "OpsManager*.yml"
 opsman_image_s3_versioned_regexp: "OpsManager2.3-(.*).146onAzure.yml"
 
 #┌───────────────────────────────────────────────────────────────────┐
 #├ Rendered into auth.yml                                            │
 #└───────────────────────────────────────────────────────────────────┘
 auth_config:
-  username: ((opsman_user))
+  username: ((opsman_username))
   password: ((opsman_password))
   decryption-passphrase: ((opsman_decryption_passphrase))
 
@@ -27,7 +26,7 @@ auth_config:
 env_config:
   target: ((opsman_target))
   skip-ssl-validation: true
-  username: ((opsman_user))
+  username: ((opsman_username))
   password: ((opsman_password))
   connect-timeout: 1600
   request-timeout: 600
@@ -43,14 +42,14 @@ opsman_config:
       tenant_id: ((iaas_configuration_tenant_id))
       client_id: ((iaas_configuration_client_id))
       client_secret: ((iaas_configuration_client_secret))
-      location: "East US"
+      location: "Central US"
       public_ip: ((opsman_public_ip))
       private_ip: ((opsman_private_ip))
-      container: opsmanager
+      container: ((iaas_opsman_container))
       network_security_group: ((iaas_configuration_opsman_security_group))
       vpc_network: ((vpc_network))
       vpc_subnet: ((net_mgmt_subnet))
-      storage_account: ((iaas_configuration_storage_account))
+      storage_account: ((iaas_opsman_storage_account))
       storage_key: ((iaas_configuration_storage_key))
       ssh_public_key: ((iaas_configuration_ssh_public_key))
       vm_name: opsmanager
@@ -75,7 +74,7 @@ director_config:
       enabled: false
     hm_pager_duty_options:
       enabled: false
-    identification_tags: {))
+    identification_tags: {}
     keep_unreachable_vms: false
     local_blobstore_options:
       tls_enabled: true
@@ -110,28 +109,28 @@ director_config:
     - name: Management
       subnets:
       - iaas_identifier: ((net_mgmt_iaas_id))
-        cidr: 10.0.8.0/20
+        cidr: 10.1.8.0/26
         dns: 168.63.129.16
-        gateway: 10.0.8.1
-        reserved_ip_ranges: 10.0.8.1-10.0.8.11
+        gateway: 10.1.8.1
+        reserved_ip_ranges: 10.1.8.1-10.1.8.9
         availability_zone_names:
         - "null"
     - name: Deployment
       subnets:
       - iaas_identifier: ((net_dep_iaas_id))
-        cidr: 10.0.0.0/22
+        cidr: 10.1.0.0/22
         dns: 168.63.129.16
-        gateway: 10.0.0.1
-        reserved_ip_ranges: 10.0.0.1-10.0.0.9
+        gateway: 10.1.0.1
+        reserved_ip_ranges: 10.1.0.1-10.1.0.9
         availability_zone_names:
         - "null"
     - name: Services
       subnets:
       - iaas_identifier: ((net_svcs_iaas_id))
-        cidr: 10.0.4.0/22
+        cidr: 10.1.4.0/22
         dns: 168.63.129.16
-        gateway: 10.0.4.1
-        reserved_ip_ranges: 10.0.4.1-10.0.4.9
+        gateway: 10.1.4.1
+        reserved_ip_ranges: 10.1.4.1-10.1.4.9
         availability_zone_names:
         - "null"
   resource-configuration:

--- a/install-opsman/params.yml
+++ b/install-opsman/params.yml
@@ -1,54 +1,155 @@
 ---
+#┌───────────────────────────────────────────────────────────────────┐
+#├ Globals                                                           │
+#└───────────────────────────────────────────────────────────────────┘
 s3:
-  access_key_id: ((prod_s3_access_key_id))
-  region_name: ((prod_s3_region_name))
+  access_key_id: ((s3_access_key_id))
+  region_name: ((s3_region_name))
   buckets:
-    product: ((prod_pcf_product_bucket))
-    config: ((prod_pcf_config_bucket))
-  secret_access_key: ((prod_s3_secret_access_key))
-  endpoint: ((prod_s3_endpoint))
+    product: ((s3_product_bucket))
+    config: ((s3_config_bucket))
+  secret_access_key: ((s3_secret_access_key))
+  endpoint: ((s3_endpoint))
 pivnet_token: ((pivnet_token))
-opsman_version:  ((prod_opsman_version))
 opsman_image_wildcard: "OpsManager*.yml"
-pcf_automation_version: 0.0.1-rc.214
-pas_version: ((prod_pas_version))
-healthwatch_version: ((prod_healthwatch_version))
-opsman_image_s3_versioned_regexp: ((prod_opsman_image_s3_versioned_regexp))
-opsman_target: ((prod_opsman_target))
-opsman_skip_ssl_validation: true
-opsman_user: ((prod_opsman_user))
-opsman_password: ((prod_opsman_password))
-opsman_decryption_passphrase: ((prod_opsman_passphrase))
-director_client_id: ((prod_director_client_id))
-director_client_secret: ((prod_director_client_secret))
-director_default_security_group: ((prod_director_security_group))
-director_environment: ((prod_director_environment))
-director_resource_group_name: ((prod_director_resource_group_name))
-director_ssh_public_key: ((prod_director_ssh_public_key))
-director_ssh_private_key: ((prod_director_ssh_private_key))
-director_subscription_id: ((prod_director_subscription_id))
-director_tenant_id: ((prod_director_tenant_id))
-net_dns: 168.63.129.16
-net_mgmt_iaas_id: pcf-dxc-com-virtual-network/pcf-dxc-com-management-subnet
-net_mgmt_cidr: 10.0.8.0/26
-net_mgmt_gateway: 10.0.8.1
-net_mgmt_reserved_range: 10.0.8.1-10.0.8.11
-net_dep_iaas_id: pcf-dxc-com-virtual-network/pcf-dxc-com-pas-subnet
-net_dep_cidr: 10.0.0.0/22
-net_dep_gateway: 10.0.0.1
-net_dep_reserved_range: 10.0.0.1-10.0.0.9
-net_svcs_iaas_id: pcf-dxc-com-virtual-network/pcf-dxc-com-services-subnet
-net_svcs_cidr: 10.0.4.0/22
-net_svcs_gateway: 10.0.4.1
-net_svcs_reserved_range: 10.0.4.1-10.0.4.9
-iaas_configuration_region: "East US"
-opsman_public_ip: 40.117.89.161
-opsman_private_ip: 10.0.8.11
-net_config_network: pcf-dxc-com-virtual-network
-net_config_mgmt_subnet: pcf-dxc-com-management-subnet
-director_storage_account_name: ((prod_azure_storage_account))
-iaas_configuration_storage_account: ((prod_azure_storage_account))
-iaas_configuration_storage_key: ((prod_azure_storage_key))
-opsman_vm_name: opsman
-opsman_boot_disk_size: 150
-opsman_security_group: ((prod_opsman_security_group))
+opsman_image_s3_versioned_regexp: "OpsManager2.3-(.*).146onAzure.yml"
+
+#┌───────────────────────────────────────────────────────────────────┐
+#├ Rendered into auth.yml                                            │
+#└───────────────────────────────────────────────────────────────────┘
+auth_config:
+  username: ((opsman_user))
+  password: ((opsman_password))
+  decryption-passphrase: ((opsman_decryption_passphrase))
+
+#┌───────────────────────────────────────────────────────────────────┐
+#├ Rendered into env.yml                                             │
+#└───────────────────────────────────────────────────────────────────┘
+env_config:
+  target: ((opsman_target))
+  skip-ssl-validation: true
+  username: ((opsman_user))
+  password: ((opsman_password))
+  connect-timeout: 1600
+  request-timeout: 600
+
+#┌───────────────────────────────────────────────────────────────────┐
+#├ Rendered into opsman.yml                                          │
+#└───────────────────────────────────────────────────────────────────┘
+opsman_config:
+  opsman-configuration:
+    azure:
+      subscription_id: ((iaas_configuration_subscription_id))
+      resource_group: ((iaas_configuration_resource_group_name))
+      tenant_id: ((iaas_configuration_tenant_id))
+      client_id: ((iaas_configuration_client_id))
+      client_secret: ((iaas_configuration_client_secret))
+      location: "East US"
+      public_ip: ((opsman_public_ip))
+      private_ip: ((opsman_private_ip))
+      container: opsmanager
+      network_security_group: ((iaas_configuration_opsman_security_group))
+      vpc_network: ((vpc_network))
+      vpc_subnet: ((net_mgmt_subnet))
+      storage_account: ((iaas_configuration_storage_account))
+      storage_key: ((iaas_configuration_storage_key))
+      ssh_public_key: ((iaas_configuration_ssh_public_key))
+      vm_name: opsmanager
+      boot_disk_size: 150
+
+#┌───────────────────────────────────────────────────────────────────┐
+#├ Rendered into director.yml                                        │
+#└───────────────────────────────────────────────────────────────────┘
+director_config:
+  director-configuration:
+    allow_legacy_agents: true
+    blobstore_type: local
+    bosh_recreate_on_next_deploy: false
+    bosh_recreate_persistent_disks_on_next_deploy: false
+    database_type: internal
+    director_worker_count: 5
+    encryption:
+      keys: []
+      providers: []
+    excluded_recursors: []
+    hm_emailer_options:
+      enabled: false
+    hm_pager_duty_options:
+      enabled: false
+    identification_tags: {))
+    keep_unreachable_vms: false
+    local_blobstore_options:
+      tls_enabled: true
+    ntp_servers_string: ntp.ubuntu.com
+    post_deploy_enabled: false
+    resurrector_enabled: true
+    retry_bosh_deploys: true
+  iaas-configuration:
+    bosh_storage_account_name: ((iaas_configuration_storage_account))
+    client_id: ((iaas_configuration_client_id))
+    client_secret: ((iaas_configuration_client_secret))
+    default_security_group: ((iaas_configuration_default_security_group))
+    deployments_storage_account_name: ((iaas_configuration_deployments_storage_account_name))
+    environment: ((iaas_configuration_environment))
+    resource_group_name: ((iaas_configuration_resource_group_name))
+    ssh_public_key: ((iaas_configuration_ssh_public_key))
+    ssh_private_key: ((iaas_configuration_ssh_private_key))
+    cloud_storage_type: managed_disks
+    storage_account_type: Standard_LRS
+    subscription_id: ((iaas_configuration_subscription_id))
+    tenant_id: ((iaas_configuration_tenant_id))
+  network-assignment:
+    network:
+      name: Management
+    other_availability_zones:
+    - name: "null"
+    singleton_availability_zone:
+      name: "null"
+  networks-configuration:
+    icmp_checks_enabled: false
+    networks:
+    - name: Management
+      subnets:
+      - iaas_identifier: ((net_mgmt_iaas_id))
+        cidr: 10.0.8.0/20
+        dns: 168.63.129.16
+        gateway: 10.0.8.1
+        reserved_ip_ranges: 10.0.8.1-10.0.8.11
+        availability_zone_names:
+        - "null"
+    - name: Deployment
+      subnets:
+      - iaas_identifier: ((net_dep_iaas_id))
+        cidr: 10.0.0.0/22
+        dns: 168.63.129.16
+        gateway: 10.0.0.1
+        reserved_ip_ranges: 10.0.0.1-10.0.0.9
+        availability_zone_names:
+        - "null"
+    - name: Services
+      subnets:
+      - iaas_identifier: ((net_svcs_iaas_id))
+        cidr: 10.0.4.0/22
+        dns: 168.63.129.16
+        gateway: 10.0.4.1
+        reserved_ip_ranges: 10.0.4.1-10.0.4.9
+        availability_zone_names:
+        - "null"
+  resource-configuration:
+    compilation:
+      instances: automatic
+      instance_type:
+        id: automatic
+      internet_connected: false
+    director:
+      instances: automatic
+      persistent_disk:
+        size_mb: "102400"
+      instance_type:
+        id: automatic
+      internet_connected: false
+  security-configuration:
+    generate_vm_passwords: true
+  syslog-configuration:
+    enabled: false
+  vmextensions-configuration: []

--- a/install-opsman/pipeline.yml
+++ b/install-opsman/pipeline.yml
@@ -1,4 +1,17 @@
 ---
+#┌───────────────────────────────────────────────────────────────────┐
+#├ Resources for Director/Operations Manager                         │
+#│                                                                   │
+#├ S3:                                                               │
+#│ ├── PCF Automation task                                           │
+#│ ├── PCF Automation docker image                                   │
+#│ ├── Operations Manager state file                                 │
+#│ ├── Operations Manager installation.zip                           │
+#│ └── Operations Manager image file                                 │
+#├ Time:                                                             │
+#│ ├── One-time trigger                                              │
+#│ └── Daily trigger                                                 │
+#└───────────────────────────────────────────────────────────────────┘
 resources:
 - name: pcf-automation-tasks
   type: s3
@@ -51,62 +64,6 @@ resources:
     secret_access_key: ((s3.secret_access_key))
     endpoint: ((s3.endpoint))
 
-
-- name: stemcell
-  type: s3
-  source:
-    access_key_id: ((s3.access_key_id))
-    bucket: ((s3.buckets.product))
-    regexp: bosh-stemcell-(.*)-ubuntu-trusty-go_agent.tgz
-    region_name: ((s3.region_name))
-    secret_access_key: ((s3.secret_access_key))
-    endpoint: ((s3.endpoint))
-
-- name: pas-product
-  type: s3
-  source:
-    access_key_id: ((s3.access_key_id))
-    bucket: ((s3.buckets.product))
-    regexp: cf-(.*).pivotal
-    region_name: ((s3.region_name))
-    secret_access_key: ((s3.secret_access_key))
-    endpoint: ((s3.endpoint))
-
-- name: healthwatch-product
-  type: s3
-  source:
-    access_key_id: ((s3.access_key_id))
-    bucket: ((s3.buckets.product))
-    regexp: p-healthwatch-(.*).pivotal
-    region_name: ((s3.region_name))
-    secret_access_key: ((s3.secret_access_key))
-    endpoint: ((s3.endpoint))
-
-- name: director-config
-  type: s3
-  source:
-    access_key_id: ((s3.access_key_id))
-    bucket: ((s3.buckets.config))
-    regexp: (director.*).yml
-    region_name: ((s3.region_name))
-    secret_access_key: ((s3.secret_access_key))
-    endpoint: ((s3.endpoint))
-
-- name: opsman-config
-  type: s3
-  source:
-    access_key_id: ((s3.access_key_id))
-    bucket: ((s3.buckets.config))
-    regexp: (opsman.*).yml
-    region_name: ((s3.region_name))
-    secret_access_key: ((s3.secret_access_key))
-    endpoint: ((s3.endpoint))
-
-- name: pipeline-utilities 
-  type: git
-  source:
-    uri: https://github.com/pivotalservices/pipeline-utilities.git
-
 - name: one-time-trigger
   type: time
   source:
@@ -116,14 +73,28 @@ resources:
   type: time
   source:
     interval: 24h
-
+#┌───────────────────────────────────────────────────────────────────┐
+#├ Jobs for Director/Operations Manager                              │
+#│                                                                   │
+#├ Install Operations Manager & BOSH Director:                       │
+#│ ├── Generate configurations                                       │
+#│ ├── Create Operations Manager VM                                  │
+#│ ├── Configure Operations Manager authentication (basic)           │
+#│ ├── Configure BOSH director                                       │
+#│ └── Operations Manager image file                                 │
+#├ Export Operations Manager Installation:                           │
+#│ ├── Generate environment configuration                            │
+#│ └── Export installation.zip                                       │
+#├ Upgrade Operations Manager:                                       │
+#│ ├── Generate configurations                                       │
+#│ └── Upgrade Operations Manager                                    │
+#└───────────────────────────────────────────────────────────────────┘
 jobs:
-- name: install-opsman
+- name: install-opsman-and-director
   serial: true
   serial_groups: [ install ]
   plan:
   - aggregate:
-    - get: pipeline-utilities
     - get: pcf-automation-image
       params:
         unpack: true
@@ -134,36 +105,15 @@ jobs:
         unpack: true
     - get: opsman-image
     - get: state
-    - get: director-config
-    - get: opsman-config
-  - aggregate:
-    - task: create-env-file
-      file: pipeline-utilities/tasks/create-env-file.yml
-      params:
-        OPSMAN_TARGET: ((opsman_target))
-        OPSMAN_SKIP_SSL_VALIDATION: ((opsman_skip_ssl_validation))
-        OPSMAN_USERNAME: ((opsman_user))
-        OPSMAN_PASSWORD: ((opsman_password))
-        OPSMAN_DECRYPTION_PASSPHRASE: ((opsman_decryption_passphrase))
-        OPSMAN_CONNECT_TIMEOUT: 1600
-        OPSMAN_REQUEST_TIMEOUT: 600
-    - task: create-auth-file
-      file: pipeline-utilities/tasks/create-auth-file.yml
-      params:
-        OPSMAN_TARGET: ((opsman_target))
-        OPSMAN_SKIP_SSL_VALIDATION: ((opsman_skip_ssl_validation))
-        OPSMAN_USERNAME: ((opsman_user))
-        OPSMAN_PASSWORD: ((opsman_password))
-        OPSMAN_DECRYPTION_PASSPHRASE: ((opsman_decryption_passphrase))
-        OPSMAN_CONNECT_TIMEOUT: 1600
-        OPSMAN_REQUEST_TIMEOUT: 600
-  - task: generate-opsman-and-director-config
+  - task: generate-configs
     params:
       OPSMAN_CONFIG: ((opsman_config))
       DIRECTOR_CONFIG: ((director_config))
+      AUTH_CONFIG: ((auth_config))
     config:
       outputs:
         - name: config
+        - name: env
       platform: linux
       image_resource:
         type: docker-image
@@ -174,8 +124,10 @@ jobs:
         args:
         - "-c"
         - |
-          bosh int <(echo "${OPSMAN_CONFIG}") > config/opsman.yml
+          bosh int <(echo "${AUTH_CONFIG}") > config/auth.yml
           bosh int <(echo "${DIRECTOR_CONFIG}") > config/director.yml
+          bosh int <(echo "${ENV_CONFIG}") > env/env.yml
+          bosh int <(echo "${OPSMAN_CONFIG}") > config/opsman.yml
   - task: create-vm
     image: pcf-automation-image
     file: pcf-automation-tasks/tasks/create-vm.yml
@@ -185,22 +137,7 @@ jobs:
       put: state
       params:
         file: generated-state/state.yml
-  - task: update-cached-state
-    config:
-      inputs:
-        - name: state
-        - name: generated-state
-      platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: pcfnorm/rootfs
-      run:
-        path: bash
-        args:
-        - -c
-        - cp generated-state/state.yml state/state.yml
-  - task: configure-authentication
+   - task: configure-authentication
     image: pcf-automation-image
     file: pcf-automation-tasks/tasks/configure-authentication.yml
     attempts: 10
@@ -215,7 +152,6 @@ jobs:
   serial: true
   plan:
   - aggregate:
-    - get: pipeline-utilities
     - get: daily-trigger
       trigger: true
     - get: pcf-automation-image
@@ -224,16 +160,23 @@ jobs:
     - get: pcf-automation-tasks
       params:
         unpack: true
-  - task: create-env-file
-    file: pipeline-utilities/tasks/create-env-file.yml
+  - task: generate-env
     params:
-      OPSMAN_TARGET: ((opsman_target))
-      OPSMAN_SKIP_SSL_VALIDATION: ((opsman_skip_ssl_validation))
-      OPSMAN_USERNAME: ((opsman_user))
-      OPSMAN_PASSWORD: ((opsman_password))
-      OPSMAN_DECRYPTION_PASSPHRASE: ((opsman_decryption_passphrase))
-      OPSMAN_CONNECT_TIMEOUT: 1600
-      OPSMAN_REQUEST_TIMEOUT: 600
+      OPSMAN_CONFIG: ((opsman_config))
+    config:
+      outputs:
+        - name: config
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: pivotalservices/bosh2-docker
+      run:
+        path: bash
+        args:
+        - "-c"
+        - |
+          bosh int <(echo "${OPSMAN_CONFIG}") > config/opsman.yml
   - task: export-installation
     image: pcf-automation-image
     file: pcf-automation-tasks/tasks/export-installation.yml
@@ -260,36 +203,15 @@ jobs:
       passed: [ export-installation ]
     - get: state
     - get: opsman-config
-    - get: pipeline-utilities
     - get: director-config
-  - aggregate:
-    - task: create-env-file
-      file: pipeline-utilities/tasks/create-env-file.yml
-      params:
-        OPSMAN_TARGET: ((opsman_target))
-        OPSMAN_SKIP_SSL_VALIDATION: ((opsman_skip_ssl_validation))
-        OPSMAN_USERNAME: ((opsman_user))
-        OPSMAN_PASSWORD: ((opsman_password))
-        OPSMAN_DECRYPTION_PASSPHRASE: ((opsman_decryption_passphrase))
-        OPSMAN_CONNECT_TIMEOUT: 1600
-        OPSMAN_REQUEST_TIMEOUT: 600
-    - task: create-auth-file
-      file: pipeline-utilities/tasks/create-auth-file.yml
-      params:
-        OPSMAN_TARGET: ((opsman_target))
-        OPSMAN_SKIP_SSL_VALIDATION: ((opsman_skip_ssl_validation))
-        OPSMAN_USERNAME: ((opsman_user))
-        OPSMAN_PASSWORD: ((opsman_password))
-        OPSMAN_DECRYPTION_PASSPHRASE: ((opsman_decryption_passphrase))
-        OPSMAN_CONNECT_TIMEOUT: 1600
-        OPSMAN_REQUEST_TIMEOUT: 600
-  - task: generate-opsman-and-director-config
+  - task: generate-configs
     params:
+      ENV_CONFIG: ((env_config))
       OPSMAN_CONFIG: ((opsman_config))
-      DIRECTOR_CONFIG: ((director_config))
     config:
       outputs:
         - name: config
+        - name: env
       platform: linux
       image_resource:
         type: docker-image
@@ -300,8 +222,8 @@ jobs:
         args:
         - "-c"
         - |
+          bosh int <(echo "${ENV_CONFIG}") > env/env.yml
           bosh int <(echo "${OPSMAN_CONFIG}") > config/opsman.yml
-          bosh int <(echo "${DIRECTOR_CONFIG}") > config/director.yml
   - task: upgrade-opsman
     image: pcf-automation-image
     file: pcf-automation-tasks/tasks/upgrade-opsman.yml
@@ -313,133 +235,3 @@ jobs:
       put: state
       params:
         file: generated-state/state.yml
-
-- name: upload-and-stage-pas
-  serial: true
-  plan:
-  - aggregate:
-    - get: pcf-automation-image
-      params:
-        unpack: true
-    - get: pcf-automation-tasks
-      params:
-        unpack: true
-    - get: pas-product
-  - task: upload-and-stage-product
-    image: pcf-automation-image
-    file: pcf-automation-tasks/tasks/upload-and-stage-product.yml
-    input_mapping:
-      product: pas-product
-    params:
-      CONFIG_FILE: cf.yml
-
-- name: configure-pas
-  serial: true
-  plan:
-  - aggregate:
-    - get: pcf-automation-image
-      params:
-        unpack: true
-    - get: pcf-automation-tasks
-      params:
-        unpack: true
-  - task: configure-pas
-    image: pcf-automation-image
-    file: pcf-automation-tasks/tasks/configure-product.yml
-    params:
-      CONFIG_FILE: cf.yml
-      VARS_FILES: vars/cf-vars.yml
-
-- name: upload-stemcell
-  serial: true
-  plan:
-  - aggregate:
-    - get: pcf-automation-image
-      params:
-        unpack: true
-    - get: pcf-automation-tasks
-      params:
-        unpack: true
-    - get: stemcell
-      trigger: true
-  - task: upload-stemcell
-    image: pcf-automation-image
-    file: pcf-automation-tasks/tasks/upload-stemcell.yml
-
-- name: upload-and-stage-healthwatch
-  serial: true
-  plan:
-  - aggregate:
-    - get: pcf-automation-image
-      params:
-        unpack: true
-    - get: pcf-automation-tasks
-      params:
-        unpack: true
-    - get: healthwatch-product
-  - task: upload-and-stage-product
-    image: pcf-automation-image
-    file: pcf-automation-tasks/tasks/upload-and-stage-product.yml
-    input_mapping:
-      product: healthwatch-product
-    params:
-      CONFIG_FILE: healthwatch.yml
-- name: configure-healthwatch
-  serial: true
-  plan:
-  - aggregate:
-    - get: pcf-automation-image
-      params:
-        unpack: true
-    - get: pcf-automation-tasks
-      params:
-        unpack: true
-  - task: configure-healthwatch
-    image: pcf-automation-image
-    file: pcf-automation-tasks/tasks/configure-product.yml
-    params:
-      CONFIG_FILE: healthwatch.yml
-      VARS_FILE:
-- name: apply-product-changes
-  serial: true
-  plan:
-  - aggregate:
-    - get: pcf-automation-image
-      params:
-        unpack: true
-    - get: pcf-automation-tasks
-      params:
-        unpack: true
-  - task: apply-product-changes
-    image: pcf-automation-image
-    file: pcf-automation-tasks/tasks/apply-changes.yml
-
-- name: staged-pas-config
-  plan:
-  - aggregate:
-    - get: pcf-automation-image
-      params:
-        unpack: true
-    - get: pcf-automation-tasks
-      params:
-        unpack: true
-  - task: staged-config
-    image: pcf-automation-image
-    file: pcf-automation-tasks/tasks/staged-config.yml
-    params:
-      PRODUCT_NAME: cf
-
-- name: staged-healthwatch-config
-  plan:
-  - aggregate:
-    - get: pcf-automation-image
-      params:
-        unpack: true
-    - get: pcf-automation-tasks
-      params:
-        unpack: true
-  - task: staged-config
-    image: pcf-automation-image
-    file: pcf-automation-tasks/tasks/staged-config.yml
-    params:
-      PRODUCT_NAME: p-healthwatch

--- a/install-opsman/pipeline.yml
+++ b/install-opsman/pipeline.yml
@@ -110,6 +110,7 @@ jobs:
       OPSMAN_CONFIG: ((opsman_config))
       DIRECTOR_CONFIG: ((director_config))
       AUTH_CONFIG: ((auth_config))
+      ENV_CONFIG: ((env_config))
     config:
       outputs:
         - name: config
@@ -137,7 +138,7 @@ jobs:
       put: state
       params:
         file: generated-state/state.yml
-   - task: configure-authentication
+  - task: configure-authentication
     image: pcf-automation-image
     file: pcf-automation-tasks/tasks/configure-authentication.yml
     attempts: 10
@@ -190,7 +191,7 @@ jobs:
   plan:
   - aggregate:
     - get: one-time-trigger
-      passed: [ install-opsman ]
+      passed: [ install-opsman-and-director ]
     - get: pcf-automation-image
       params:
         unpack: true
@@ -202,8 +203,6 @@ jobs:
     - get: installation
       passed: [ export-installation ]
     - get: state
-    - get: opsman-config
-    - get: director-config
   - task: generate-configs
     params:
       ENV_CONFIG: ((env_config))


### PR DESCRIPTION
TL;DR
------
This changes the behavior of the Opsman/Director Config generation to use the new style of abusing `bosh int` to render JSON into YAML.

Changes
---------
- Stop using `pipeline-utilities` as a resource
- Refactor tasks to generate `env.yml` using `bosh int`
- Refactor tasks to generate `director.yml` using `bosh int`
- Refactor tasks to generate `opsman.yml` using `bosh int`
- Remove unused tasks related to:
   - Healthwatch
   - PAS
